### PR TITLE
Navegacao usando query string como parametros

### DIFF
--- a/Xamarin.Community.BR/Xamarin.Community.BR/Abstractions/INavegacaoService.cs
+++ b/Xamarin.Community.BR/Xamarin.Community.BR/Abstractions/INavegacaoService.cs
@@ -4,7 +4,7 @@ namespace Xamarin.Community.BR.Abstractions
 {
     public interface INavegacaoService
     {
-        void Init();
         Task NavegarAsync(string url);
+        Task NavegarAsync(string url, bool animado);
     }
 }

--- a/Xamarin.Community.BR/Xamarin.Community.BR/App.xaml
+++ b/Xamarin.Community.BR/Xamarin.Community.BR/App.xaml
@@ -6,6 +6,6 @@
              mc:Ignorable="d"
              x:Class="Xamarin.Community.BR.App">
     <Application.Resources>
-
+        <Color x:Key="PaginaBackgroundColor">#f5f5f5</Color>
     </Application.Resources>
 </Application>

--- a/Xamarin.Community.BR/Xamarin.Community.BR/App.xaml.cs
+++ b/Xamarin.Community.BR/Xamarin.Community.BR/App.xaml.cs
@@ -16,15 +16,13 @@ namespace Xamarin.Community.BR
             TaskExtensions.DefinirAoDispararExcecaoPadrao(ex => Console.WriteLine(ex));
 
             var startup = new Startup();
-            startup.Init();
 
             _navegacaoService = startup.PegarNavegacao();
-
+            _navegacaoService.NavegarAsync("MainPage").TentarExecutar();
         }
 
         protected override void OnStart()
         {
-            _navegacaoService.NavegarAsync("MainPage").TentarExecutar();
         }
 
         protected override void OnSleep()

--- a/Xamarin.Community.BR/Xamarin.Community.BR/Constantes.cs
+++ b/Xamarin.Community.BR/Xamarin.Community.BR/Constantes.cs
@@ -2,9 +2,19 @@
 {
     public static class Constantes
     {
+        public static class Navegacao
+        {
+            public const string URL_RELATIVA = "/";
+            public const string URL_REMOCAO = "../";
+            public const string DELIMITADOR_QUERY = "?";
+        }
+
         public static class Gravatar
         {
-            public const string URL_BASE = "";
+            /// <see href="https://github.com/planetxamarin/planetxamarin/blob/7fd6555be5a34a95badc26ec053f448a5bf93961/src/Firehose.Web/Views/Authors/Map.cshtml#L59"/>
+            public const string URL_BASE = "https://www.gravatar.com/avatar/";
+
+            public const int TAMANHO_PADRAO = 64;
         }
 
         public static class SVG

--- a/Xamarin.Community.BR/Xamarin.Community.BR/Extensions/PinExtensions.cs
+++ b/Xamarin.Community.BR/Xamarin.Community.BR/Extensions/PinExtensions.cs
@@ -9,11 +9,20 @@ namespace Xamarin.Community.BR.Extensions
     {
         public static Pin ToPin(this IAmACommunityMember membro)
         {
-            var avatarUri = new Uri($"{Constantes.Gravatar.URL_BASE}{membro.GravatarHash}");
-            var avatar = ImageSource.FromUri(avatarUri);
+            var avatar = PegarAvatar(membro);
             var localizacao = membro.Localizacao;
-            
+
             return new Pin(localizacao.Latitude, localizacao.Longitude, avatar);
+        }
+
+        private static ImageSource PegarAvatar(IAmACommunityMember membro)
+        {
+            if (string.IsNullOrWhiteSpace(membro.GravatarHash))
+                return null;
+
+            var avatarUri = new Uri($"{Constantes.Gravatar.URL_BASE}{membro.GravatarHash}.jpg?s={Constantes.Gravatar.TAMANHO_PADRAO}&d=mm");
+            var avatar = ImageSource.FromUri(avatarUri);
+            return avatar;
         }
     }
 }

--- a/Xamarin.Community.BR/Xamarin.Community.BR/Services/NavegacaoService.cs
+++ b/Xamarin.Community.BR/Xamarin.Community.BR/Services/NavegacaoService.cs
@@ -1,6 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web;
 using TinyIoC;
 using Xamarin.Community.BR.Abstractions;
 using Xamarin.Community.BR.Helpers;
@@ -8,8 +11,9 @@ using Xamarin.Forms;
 
 namespace Xamarin.Community.BR.Services
 {
-    public class NavegacaoService : INavegacaoService
+    public sealed class NavegacaoService : INavegacaoService
     {
+        private NavigationPage _navegacao;
         private TinyIoCContainer _container;
         private CancellationTokenSource cancellationTokenSource;
 
@@ -18,31 +22,101 @@ namespace Xamarin.Community.BR.Services
             _container = container;
         }
 
-        public void Init()
+        public async Task NavegarAsync(string url) =>
+            await NavegarInternoAsync(url, false).ConfigureAwait(false);
+
+        public async Task NavegarAsync(string url, bool animar) =>
+            await NavegarInternoAsync(url, animar).ConfigureAwait(false);
+
+        private async Task NavegarInternoAsync(string url, bool animar)
         {
-            Application.Current.MainPage = new NavigationPage();
+            if (!url.StartsWith(Constantes.Navegacao.URL_RELATIVA) &&
+                !url.StartsWith(Constantes.Navegacao.URL_REMOCAO))
+            {
+                SubstituirRaiz(url);
+                return;
+            }
+
+            var uri = new Uri(url);
+            var segmentos = uri.Segments.Where(s => !Constantes.Navegacao.URL_RELATIVA.Equals(s));
+            foreach (var segmento in segmentos)
+            {
+                var segmentoDecoded = HttpUtility.UrlDecode(segmento);
+                var indiceQuery = segmentoDecoded.IndexOf(Constantes.Navegacao.DELIMITADOR_QUERY) + 1;
+                var query = indiceQuery > 0
+                    ? segmentoDecoded.Substring(indiceQuery)
+                    : null;
+
+                var pagina = segmentoDecoded.Replace($"{Constantes.Navegacao.DELIMITADOR_QUERY}{query}", string.Empty);
+                var parametros = query?
+                    .Split('&')
+                    .Select(q=> q.Split('='))
+                    .ToDictionary(p=> p[0], p=> p[1]);
+
+                await EmpilharPaginaAsync(pagina, parametros, animar).ConfigureAwait(false);
+            }
         }
 
-        public async Task NavegarAsync(string url)
+        private void SubstituirRaiz(string url)
         {
-            if(Application.Current.MainPage is NavigationPage nav)
+            var uri = new Uri($"/{url}");
+            var nomePagina = uri.Segments.First(s => !Constantes.Navegacao.URL_RELATIVA.Equals(s));
+            var pagina = ResolverPagina(nomePagina);
+            Application.Current.MainPage = _navegacao = new NavigationPage(pagina);
+
+            DispararCarregar(pagina, ResolverCancellationToken());
+        }
+
+        private async Task EmpilharPaginaAsync(string nomePagina, IDictionary<string, string> parametros, bool animar)
+        {
+            var pagina = ResolverPagina(nomePagina, parametros);
+            await _navegacao.PushAsync(pagina, animar).ConfigureAwait(false);
+            DispararCarregar(pagina, ResolverCancellationToken());
+        }
+
+        private CancellationToken ResolverCancellationToken()
+        {
+            cancellationTokenSource?.Cancel();
+            cancellationTokenSource?.Dispose();
+            cancellationTokenSource = new CancellationTokenSource();
+
+            return cancellationTokenSource.Token;
+        }
+
+        private Page ResolverPagina(string url, IDictionary<string, string> parametros = null)
+        {
+            var tipoPagina = Type.GetType($"Xamarin.Community.BR.Views.Paginas.{url}");
+            var pagina = (Page)_container.Resolve(tipoPagina);
+
+            ViewModelLocator.LocalizaViewModel(pagina, _container);
+            ResolverParametros(pagina, parametros);
+
+            return pagina;
+        }
+
+        private static void ResolverParametros(Page pagina, IDictionary<string, string> parametros)
+        {
+            if (parametros is null)
+                return;
+
+            var vmType = pagina.BindingContext.GetType();
+            foreach (var parametro in parametros)
             {
-                var tipoPagina = Type.GetType($"Xamarin.Community.BR.Views.Paginas.{url}");
-                var pagina = (Page)_container.Resolve(tipoPagina);
-
-                ViewModelLocator.LocalizaViewModel(pagina, _container);
-
-                cancellationTokenSource?.Cancel();
-                cancellationTokenSource?.Dispose();
-                cancellationTokenSource = new CancellationTokenSource();
-
-                await nav.PushAsync(pagina).ConfigureAwait(false);
-
-                if(pagina.BindingContext is ICarregar carregar)
+                var propriedade = vmType.GetProperty(parametro.Key);
+                if (propriedade != null)
                 {
-                    await carregar.CarregarAsync(cancellationTokenSource.Token).ConfigureAwait(false);
+                    propriedade.SetValue(pagina.BindingContext, parametro.Value);
                 }
             }
+        }
+
+        private void DispararCarregar(Page pagina, CancellationToken token)
+        {
+            if (pagina is ICarregar paginaCarregar)
+                Task.Run(() => paginaCarregar.CarregarAsync(token));
+
+            if (pagina.BindingContext is ICarregar VMcarregar)
+                Task.Run(() => VMcarregar.CarregarAsync(token));
         }
     }
 }

--- a/Xamarin.Community.BR/Xamarin.Community.BR/Startup.cs
+++ b/Xamarin.Community.BR/Xamarin.Community.BR/Startup.cs
@@ -14,12 +14,8 @@ namespace Xamarin.Community.BR
         public Startup()
         {
             _container = TinyIoCContainer.Current;
-            _navegacao = new NavegacaoService(_container);
-        }
 
-        public void Init()
-        {
-            _navegacao.Init();
+            _navegacao = new NavegacaoService(_container);
             _container.Register<INavegacaoService>(_navegacao);
             _container.Register<IPerfilService, PerfilService>();
             _container.Register<MainPageViewModel>();

--- a/Xamarin.Community.BR/Xamarin.Community.BR/ViewModels/Paginas/DevsPageViewModel.cs
+++ b/Xamarin.Community.BR/Xamarin.Community.BR/ViewModels/Paginas/DevsPageViewModel.cs
@@ -1,0 +1,28 @@
+﻿using System.Windows.Input;
+using Xamarin.Forms;
+
+namespace Xamarin.Community.BR.ViewModels.Paginas
+{
+    public sealed class DevsPageViewModel : BaseViewModel
+    {
+        public ICommand PesquisaCommand { get; }
+
+        private string texto;
+
+        public string Texto
+        {
+            get => texto;
+            set => SetProperty(ref texto, value);
+        }
+
+        public DevsPageViewModel()
+        {
+            PesquisaCommand = new Command(PesquisaCommandExecute);
+        }
+
+        private void PesquisaCommandExecute(object obj)
+        {
+            //Todo
+        }
+    }
+}

--- a/Xamarin.Community.BR/Xamarin.Community.BR/ViewModels/Paginas/MainPageViewModel.cs
+++ b/Xamarin.Community.BR/Xamarin.Community.BR/ViewModels/Paginas/MainPageViewModel.cs
@@ -12,6 +12,7 @@ namespace Xamarin.Community.BR.ViewModels.Paginas
     public sealed class MainPageViewModel : BaseViewModel, ICarregar
     {
         private readonly IPerfilService _perfilService;
+        private readonly INavegacaoService _navegacaoService;
 
         private IEnumerable<IAmACommunityMember> listaProgramadores;
 
@@ -19,11 +20,18 @@ namespace Xamarin.Community.BR.ViewModels.Paginas
 
         public ICommand PesquisaCommand { get; }
 
-        public MainPageViewModel(IPerfilService perfilService)
+        public ICommand DevsPageCommand { get; }
+
+        public MainPageViewModel(
+            IPerfilService perfilService,
+            INavegacaoService navegacaoService)
         {
             _perfilService = perfilService;
+            _navegacaoService = navegacaoService;
+
             Pins = new ObservableCollection<IPin>();
             PesquisaCommand = new Command(PesquisaCommandExecute, (obj) => !EstaOcupado);
+            DevsPageCommand = new Command(DevsPageCommandExecute, (obj) => !EstaOcupado);
         }
 
         public async Task CarregarAsync(CancellationToken token) =>
@@ -40,6 +48,11 @@ namespace Xamarin.Community.BR.ViewModels.Paginas
             }
 
             return Task.CompletedTask;
+        }
+
+        private void DevsPageCommandExecute(object obj)
+        {
+            _navegacaoService.NavegarAsync("/DevsPage?Texto=Olá da query string", true).TentarExecutar();
         }
 
         private void PesquisaCommandExecute(object obj)

--- a/Xamarin.Community.BR/Xamarin.Community.BR/Views/Controles/BarraNavegacao.xaml.cs
+++ b/Xamarin.Community.BR/Xamarin.Community.BR/Views/Controles/BarraNavegacao.xaml.cs
@@ -11,6 +11,9 @@ namespace Xamarin.Community.BR.Views.Controles
         public static readonly BindableProperty PesquisaCommandProperty =
             BindableProperty.Create(nameof(PesquisaCommand), typeof(ICommand), typeof(BarraNavegacao), defaultValue: default(ICommand), defaultBindingMode: BindingMode.OneTime);
 
+        public static readonly BindableProperty BotaoInferiorCommandProperty =
+            BindableProperty.Create(nameof(BotaoInferiorCommand), typeof(ICommand), typeof(BarraNavegacao), defaultValue: default(ICommand), defaultBindingMode: BindingMode.OneTime);
+
         public static readonly BindableProperty PesquisaTextoProperty =
             BindableProperty.Create(nameof(PesquisaTexto), typeof(string), typeof(BarraNavegacao), defaultValue: string.Empty, defaultBindingMode: BindingMode.TwoWay, propertyChanged: AlterarTexto);
 
@@ -22,6 +25,12 @@ namespace Xamarin.Community.BR.Views.Controles
         {
             get => (ICommand)GetValue(PesquisaCommandProperty);
             set => SetValue(PesquisaCommandProperty, value);
+        }
+
+        public ICommand BotaoInferiorCommand
+        {
+            get => (ICommand)GetValue(BotaoInferiorCommandProperty);
+            set => SetValue(BotaoInferiorCommandProperty, value);
         }
 
         public string PesquisaTexto
@@ -59,8 +68,8 @@ namespace Xamarin.Community.BR.Views.Controles
                 if (PesquisaCommand == null)
                     return;
 
-                if (PesquisaCommand.CanExecute(this))
-                    PesquisaCommand.Execute(this);
+                if (PesquisaCommand.CanExecute(pesquisaEntry.Text))
+                    PesquisaCommand.Execute(pesquisaEntry.Text);
             }
             else
             {
@@ -75,6 +84,9 @@ namespace Xamarin.Community.BR.Views.Controles
                 return;
 
             AnimarXamarinoCimaAsync().TentarExecutar();
+
+            if (BotaoInferiorCommand?.CanExecute(this) == true)
+                BotaoInferiorCommand?.Execute(this);
         }
 
         private async Task AnimarXamarinoCimaAsync()

--- a/Xamarin.Community.BR/Xamarin.Community.BR/Views/Paginas/DevsPage.xaml
+++ b/Xamarin.Community.BR/Xamarin.Community.BR/Views/Paginas/DevsPage.xaml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:controles="clr-namespace:Xamarin.Community.BR.Views.Controles"
+             xmlns:vm="clr-namespace:Xamarin.Community.BR.ViewModels.Paginas"
+             x:Class="Xamarin.Community.BR.Views.Paginas.DevsPage"
+             x:DataType="vm:DevsPageViewModel"
+             BackgroundColor="{StaticResource PaginaBackgroundColor}"
+             NavigationPage.HasNavigationBar="False">
+    <ContentPage.Content>
+        <Grid RowDefinitions="15*,73.5*,11.5*"
+              RowSpacing="0">
+
+            <Label Text="{Binding Texto, Mode=OneWay}"
+                   VerticalOptions="CenterAndExpand"
+                   HorizontalOptions="CenterAndExpand"
+                   Grid.Row="1"/>
+
+            <controles:BarraNavegacao x:Name="navegacao"
+                                  PesquisaCommand="{Binding PesquisaCommand, Mode=OneTime}"
+                                  Grid.Row="2"
+                                  Padding="2"/>
+        </Grid>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Community.BR/Xamarin.Community.BR/Views/Paginas/DevsPage.xaml.cs
+++ b/Xamarin.Community.BR/Xamarin.Community.BR/Views/Paginas/DevsPage.xaml.cs
@@ -1,0 +1,12 @@
+﻿using Xamarin.Forms;
+
+namespace Xamarin.Community.BR.Views.Paginas
+{
+    public partial class DevsPage : ContentPage
+    {
+        public DevsPage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Xamarin.Community.BR/Xamarin.Community.BR/Views/Paginas/MainPage.xaml
+++ b/Xamarin.Community.BR/Xamarin.Community.BR/Views/Paginas/MainPage.xaml
@@ -6,10 +6,9 @@
              xmlns:controles="clr-namespace:Xamarin.Community.BR.Views.Controles"
              xmlns:vm="clr-namespace:Xamarin.Community.BR.ViewModels.Paginas"
              xmlns:gr="clr-namespace:Xamarin.Community.BR.Renderers.Gradients"
-             xmlns:ex="clr-namespace:Xamarin.Community.BR.Extensions"
              x:DataType="vm:MainPageViewModel"
              mc:Ignorable="d"
-             BackgroundColor="#f5f5f5"
+             BackgroundColor="{StaticResource PaginaBackgroundColor}"
              NavigationPage.HasNavigationBar="False"
              x:Class="Xamarin.Community.BR.Views.Paginas.MainPage">
     <Grid RowDefinitions="10*,10*,68*,10*,1.5*"
@@ -58,6 +57,7 @@
 
         <controles:BarraNavegacao x:Name="navegacao"
                                   PesquisaCommand="{Binding PesquisaCommand, Mode=OneTime}"
+                                  BotaoInferiorCommand="{Binding DevsPageCommand, Mode=OneTime}"
                                   Grid.Row="3"
                                   Padding="2"
                                   Grid.RowSpan="2"/>

--- a/Xamarin.Community.BR/Xamarin.Community.BR/Xamarin.Community.BR.csproj
+++ b/Xamarin.Community.BR/Xamarin.Community.BR/Xamarin.Community.BR.csproj
@@ -30,6 +30,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Update="Views\Paginas\DevsPage.xaml.cs">
+      <DependentUpon>DevsPage.xaml</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
     <EmbeddedResource Update="Views\Controles\BarraNavegacao.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
@@ -46,6 +52,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Update="Views\Controles\Xamarino.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Views\Paginas\DevsPage.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
﻿### Descriçao
Implementados parametros via query string na navegação

### Alteraçoes
- Reflection para setar as propriedades da viewmodel pela query string de navegação
- Ajustes no `ICarregar` para "disparar e esquecer" (Task.Run)
- Criadas `DevsPage` e `DevsPageViewModel`
- Ajustes no serviço de navegação para resolver `Uri`
- Ajustes menores

### Plataformas afetadas
- Todas

### Demo

![navegacao-query-string](https://user-images.githubusercontent.com/19656249/97379487-ad3b1b80-18a3-11eb-9110-8ad11f746730.gif)


### PR Checklist ###

- [ ] PR direcionado para o branch correto
- [ ] PR atualizado pelo branch de destino
- [ ] Alterações estão seguindo o padrão da codigicação